### PR TITLE
Better Usability and Continuity

### DIFF
--- a/HackQ/SiteEncoding.swift
+++ b/HackQ/SiteEncoding.swift
@@ -10,9 +10,6 @@ import Foundation
 import Cocoa
 import KeychainSwift
 
-private let googleSearchAPIKeyConstant = "GOOGLE_API_KEY"
-private let googleSearchSearchEngineIDConstant = "GOOGLE_CSE_ID"
-
 /**
  Determines what site will be searched for answers
 
@@ -49,7 +46,7 @@ struct SiteEncoding : Equatable, CustomStringConvertible, CustomDebugStringConve
             var queryItems = (components.queryItems ?? []) + [URLQueryItem(name: "q", value: urlEncoded)]
             var keys = [String]()
             var count = 0
-            while let apiKey = SiteEncoding.keychain.get(googleSearchAPIKeyConstant + "\(count == 0 ? "" : "\(count)")")
+            while let apiKey = SiteEncoding.keychain.get(googleAPIKeyConstant + "\(count == 0 ? "" : "\(count)")")
             {
                 keys.append(apiKey)
                 count += 1
@@ -72,7 +69,7 @@ struct SiteEncoding : Equatable, CustomStringConvertible, CustomDebugStringConve
     }
 
     static let google : SiteEncoding = {
-        guard let apiKey = keychain.get(googleSearchAPIKeyConstant), let searchEngineID = keychain.get(googleSearchSearchEngineIDConstant) else
+        guard let apiKey = keychain.get(googleAPIKeyConstant), let searchEngineID = keychain.get(googleCSEKeyConstant) else
         {
             return SiteEncoding(name: "Invalid Google Search.  Missing API Key or SearchEngineID", url: nil)
         }
@@ -86,9 +83,9 @@ struct SiteEncoding : Equatable, CustomStringConvertible, CustomDebugStringConve
         var count = 0
         for apiKey in apiKeys where apiKey != ""
         {
-            keychain.set(apiKey, forKey: googleSearchAPIKeyConstant + "\(count == 0 ? "" : "\(count)")")
+            keychain.set(apiKey, forKey: googleAPIKeyConstant + "\(count == 0 ? "" : "\(count)")")
             count += 1
         }
-        keychain.set(searchEngineID, forKey: googleSearchSearchEngineIDConstant)
+        keychain.set(searchEngineID, forKey: googleCSEKeyConstant)
     }
 }

--- a/HackQ/ViewController.swift
+++ b/HackQ/ViewController.swift
@@ -11,6 +11,11 @@ import Alamofire
 import SwiftyJSON
 import SwiftWebSocket
 
+let bearerTokenConstant = "BEARER_TOKEN_HERE"
+let userIDConstant = "USER_ID"
+let googleAPIKeyConstant = "GOOGLE_API_KEY"
+let googleCSEKeyConstant = "GOOGLE_CSE_KEY"
+
 class ViewController: NSViewController, NSTextFieldDelegate {
 
     /*
@@ -28,7 +33,7 @@ class ViewController: NSViewController, NSTextFieldDelegate {
 
     let hqheaders : HTTPHeaders = [
         "x-hq-client": "iOS/1.2.17",
-        "Authorization": "Bearer BEARER_TOKEN_HERE",
+        "Authorization": "Bearer \(bearerTokenConstant)",
         "x-hq-stk": "MQ==",
         "Host": "api-quiz.hype.space",
         "Connection": "Keep-Alive",
@@ -47,14 +52,14 @@ class ViewController: NSViewController, NSTextFieldDelegate {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
 
-        SiteEncoding.addGoogleAPICredentials(apiKeys: ["GOOGLE_API_KEY"], searchEngineID: "GOOGLE_CSE_ID")
+        SiteEncoding.addGoogleAPICredentials(apiKeys: [googleAPIKeyConstant], searchEngineID: googleCSEKeyConstant)
 
         updateLabels()
         getSocketURL()
     }
 
     func getSocketURL() {
-        Alamofire.request("https://api-quiz.hype.space/shows/now?type=hq&userId=USER_ID", headers: hqheaders).responseJSON { response in
+        Alamofire.request("https://api-quiz.hype.space/shows/now?type=hq&userId=\(userIDConstant)", headers: hqheaders).responseJSON { response in
             if let result = response.result.value {
                 let json = JSON(result)
                 let broadcast = json["broadcast"]
@@ -80,7 +85,7 @@ class ViewController: NSViewController, NSTextFieldDelegate {
         var request = URLRequest(url: URL(string: socketUrl)!)
         request.timeoutInterval = 5
         request.addValue("iOS/1.2.17", forHTTPHeaderField: "x-hq-client")
-        request.addValue("Bearer BEARER_TOKEN_HERE", forHTTPHeaderField: "Authorization")
+        request.addValue("Bearer \(bearerTokenConstant)", forHTTPHeaderField: "Authorization")
         request.addValue("MQ==", forHTTPHeaderField: "x-hq-stk")
         request.addValue("api-quiz.hype.space", forHTTPHeaderField: "Host")
         request.addValue("Keep-Alive", forHTTPHeaderField: "Connection")

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - Bearer Token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjExNjY0NTUzLCJ1c2VybmFtZSI6InRydW1wZnRxIiwiYXZhdGFyVXJsIjoiczM6Ly9oeXBlc3BhY2UtcXVpei9kZWZhdWx0X2F2YXRhcnMvVW50aXRsZWQtMV8wMDAxX2JsdWUucG5nIiwidG9rZW4iOm51bGwsInJvbGVzIjpbXSwiY2xpZW50IjoiIiwiZ3Vlc3RJZCI6bnVsbCwidiI6MSwiaWF0IjoxNTE5NTEyMTEyLCJleHAiOjE1MjcyODgxMTIsImlzcyI6Imh5cGVxdWl6LzEifQ.YxOrP_MnZTapJq5kZSmDd3MzG07W8ZeHcluI2l4cZWI
 - User ID: 11664553
 
-### Fill in info in lines 31, 50, 57 at the end of the link, and 83 of ViewController.swift and lines 13, and 14 in SiteEncoding.swift
+### Fill in info in lines 14-17 of ViewController.swift
 
 ## How it works:
 - Uses Alamofire to make a request to the host


### PR DESCRIPTION
- Added constants to the top of ViewController for CSE ID, API Key, User ID, and Bearer Token
- Removed original constants from SiteEncoding.swift in place of new constants defined in ViewController.swift
- Updated README to reflect changes

This time my personal API Key and CSE key are no longer in there. XD